### PR TITLE
Fix example command and change division operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Example you can run using the test_data provided in this repo (_test_data/sample
 
 First run the first script: _calcualte_coverages.py_
 ```
-$ python calculate_coverages.py -i test_data/ -o test_data/sample_output.tsv -d databases/WoL/metadata.tsv
+$ python calculate_coverages.py -i test_data/sample_alignments/ -o test_data/sample_output.tsv -d databases/WoL/metadata.tsv
 ```
 View output
 ```

--- a/calculate_coverages.py
+++ b/calculate_coverages.py
@@ -77,7 +77,7 @@ def calculate_coverages(input, output, database):
     #####################
     #Calculate coverages#
     #####################
-    #Make dataframe from dicitonary of coverages of each contig
+    #Make dataframe from dictionary of coverages of each contig
     cov = pd.DataFrame(
         {
             "gotu": list(gotu_dict.keys()),
@@ -89,7 +89,7 @@ def calculate_coverages(input, output, database):
     #Add genome metadata
     cov = cov.join(md, how="left")
     #Calculate coverage percent
-    cov["coverage_ratio"] = cov.apply(func= lambda x : x["covered_length"]/x["total_length"], axis=1)
+    cov["coverage_ratio"] = cov['covered_length'] / cov['total_length']
     cov = cov.loc[:,["covered_length","total_length","coverage_ratio","strain"]]
 
     ##############


### PR DESCRIPTION
The change to the command is to point to a directory that exists. When you point to a directory that contains no SAM files, you would get the following error:

```python
Traceback (most recent call last):
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2898, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1675, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1683, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'coverage_ratio'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/generic.py", line 3576, in _set_item
    loc = self._info_axis.get_loc(key)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2900, in get_loc
    raise KeyError(key) from err
KeyError: 'coverage_ratio'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "calculate_coverages.py", line 102, in <module>
    calculate_coverages()
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "calculate_coverages.py", line 93, in calculate_coverages
    cov["coverage_ratio"] = cov.apply(func= lambda x : x["covered_length"]/x["total_length"], axis=1)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/frame.py", line 3044, in __setitem__
    self._set_item(key, value)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/frame.py", line 3121, in _set_item
    NDFrame._set_item(self, key, value)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/generic.py", line 3579, in _set_item
    self._mgr.insert(len(self._info_axis), key, value)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/internals/managers.py", line 1198, in insert
    block = make_block(values=value, ndim=self.ndim, placement=slice(loc, loc + 1))
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/internals/blocks.py", line 2744, in make_block
    return klass(values, ndim=ndim, placement=placement)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/internals/blocks.py", line 2400, in __init__
    super().__init__(values, ndim=ndim, placement=placement)
  File "/Users/yoshiki/miniconda3/envs/mg/lib/python3.6/site-packages/pandas/core/internals/blocks.py", line 131, in __init__
    f"Wrong number of items passed {len(self.values)}, "
ValueError: Wrong number of items passed 3, placement implies 1
```

After the change to the division operation this line doesn't raise an exception anymore.
